### PR TITLE
Update for compatibility with julia 1.4

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,12 +5,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "ba6c5b7893e5fc90b4ff26cc061b50f715af0449"
-pinned = true
-repo-rev = "2a470e5"
-repo-url = "https://github.com/julia-vscode/CSTParser.jl.git"
+git-tree-sha1 = "46ad13fcdde8dcb144f019b08bbd36be04cd429b"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "2.0.1-DEV"
+version = "2.2.1"
 
 [[Dates]]
 deps = ["Printf"]
@@ -22,12 +19,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocumentFormat]]
 deps = ["CSTParser", "FilePathsBase", "Tokenize"]
-git-tree-sha1 = "a319f2300c1b31dee2497b0265e65b5ad7b61142"
-pinned = true
-repo-rev = "8137c72"
-repo-url = "https://github.com/julia-vscode/DocumentFormat.jl.git"
+git-tree-sha1 = "6ecbdc4d15126a89a689290a9e1aa0ce1d0a30e4"
 uuid = "ffa9a821-9c82-50df-894e-fbcef3ed31cd"
-version = "1.1.2-DEV"
+version = "2.1.1"
 
 [[FilePathsBase]]
 deps = ["Dates", "LinearAlgebra", "Printf", "Test", "UUIDs"]
@@ -46,15 +40,13 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LanguageServer]]
-deps = ["CSTParser", "DocumentFormat", "JSON", "REPL", "StaticLint", "SymbolServer", "Tokenize", "URIParser"]
-git-tree-sha1 = "148c75aa5172341b613303a8000f583a2f0f3f34"
-pinned = true
-repo-rev = "1b8750e"
-repo-url = "https://github.com/julia-vscode/LanguageServer.jl.git"
+deps = ["CSTParser", "DocumentFormat", "JSON", "REPL", "StaticLint", "SymbolServer", "Tokenize", "URIParser", "UUIDs"]
+git-tree-sha1 = "a526adeb56d15eafbeeedda48d6c8bb3ab24fd64"
 uuid = "2b0e0bc5-e4fd-59b4-8912-456d1b03d8d7"
-version = "1.1.0-DEV"
+version = "2.0.1"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -76,9 +68,9 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "0139ba59ce9bc680e2925aec5b7db79065d60556"
+git-tree-sha1 = "75d07cb840c300084634b4991761886d0d762724"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.10"
+version = "1.0.1"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -107,30 +99,24 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[StaticLint]]
 deps = ["CSTParser", "Serialization", "SymbolServer"]
-git-tree-sha1 = "e4c3e45dcaa4c0d9627deb00d77fc3cb47b1912e"
-pinned = true
-repo-rev = "4ae43e4"
-repo-url = "https://github.com/julia-vscode/StaticLint.jl.git"
+git-tree-sha1 = "2c2d34f25c05e47462e562d0d9887de9cc652143"
 uuid = "b3cc710f-9c33-5bdb-a03d-a94903873e97"
-version = "3.0.1-DEV"
+version = "3.1.1"
 
 [[SymbolServer]]
-deps = ["LibGit2", "Pkg", "SHA", "Serialization"]
-git-tree-sha1 = "19358a3a6c5ca59792b7b5588c68c59af035be3a"
-pinned = true
-repo-rev = "764ed2c"
-repo-url = "https://github.com/julia-vscode/SymbolServer.jl.git"
+deps = ["LibGit2", "Markdown", "Pkg", "REPL", "SHA", "Serialization", "Sockets", "UUIDs"]
+git-tree-sha1 = "a426ac836b7bc6cce4108ecfa1f299f4649dd80a"
 uuid = "cf896787-08d5-524d-9de7-132aaa0cb996"
-version = "2.0.1-DEV"
+version = "3.1.1"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[Tokenize]]
-git-tree-sha1 = "c3aab236f122445406cf7a6de8af0b794da5a950"
+git-tree-sha1 = "73c00ad506d88a7e8e4f90f48a70943101728227"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.7"
+version = "0.5.8"
 
 [[URIParser]]
 deps = ["Test", "Unicode"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,9 @@
 [deps]
 LanguageServer = "2b0e0bc5-e4fd-59b4-8912-456d1b03d8d7"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SymbolServer = "cf896787-08d5-524d-9de7-132aaa0cb996"
 
 [compat]
-julia = "1"
 LanguageServer = "2.0.1"
 SymbolServer = "3.1.1"
+julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,8 @@
 [deps]
-CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-DocumentFormat = "ffa9a821-9c82-50df-894e-fbcef3ed31cd"
 LanguageServer = "2b0e0bc5-e4fd-59b4-8912-456d1b03d8d7"
-StaticLint = "b3cc710f-9c33-5bdb-a03d-a94903873e97"
 SymbolServer = "cf896787-08d5-524d-9de7-132aaa0cb996"
+
+[compat]
+julia = "1"
+LanguageServer = "2.0.1"
+SymbolServer = "3.1.1"

--- a/README.org
+++ b/README.org
@@ -1,9 +1,8 @@
 * eglot-jl
 
 This is a simple package to make using [[https://github.com/julia-vscode/LanguageServer.jl][Julia's language server]] easier
-with [[https://github.com/joaotavora/eglot][eglot]]. It can be installed from
-[melpa](https://melpa.org/#/eglot-jl) by [[https://melpa.org/#/getting-started][adding melpa to your
-=package-archives=]] and doing =M-x package-install RET eglot-jl RET=
+with [[https://github.com/joaotavora/eglot][eglot]]. It can be installed from [[https://melpa.org/#/eglot-jl][melpa]] by [[https://melpa.org/#/getting-started][adding melpa to your
+~package-archives~ ]] and doing =M-x package-install RET eglot-jl RET=
 with Emacs 26.1+.
 
 After installation the interactive function ~eglot-jl-init~ will load
@@ -28,7 +27,11 @@ To work around this issue, you can:
 1. Set =eglot-connect-timeout= to a very high value.
    - Progress of the SymbolServer can be monitored in the =*EGLOT
      (ProjectName/julia-mode) stderr*= buffer.
-2. Run =julia path/to/eglot-jl/eglot-jl.jl path/to/project ""=
+2. Run the following:
+
+#+begin_src sh
+  JULIA_LOAD_PATH="@" julia --project=path/to/eglot-jl/ path/to/eglot-jl/eglot-jl.jl path/to/project ""
+#+end_src
 
 The SymbolServer is finished with caching dependencies when it
 displays:

--- a/eglot-jl.el
+++ b/eglot-jl.el
@@ -77,10 +77,14 @@ Otherwise returns nil"
 
 (defun eglot-jl--ls-invocation (_interactive)
   "Return list of strings to be called to start the Julia language server."
-  `(,eglot-jl-julia-command
-    ,(expand-file-name "eglot-jl.jl" eglot-jl-base)
-    ,(eglot-jl--env (buffer-file-name))
-    ,eglot-jl-depot))
+  ;; The eglot-jl.jl script deletes this environment variable so that
+  ;; subsequent julia processes will use the default LOAD_PATH.
+  (setenv "JULIA_LOAD_PATH" "@")
+  (list eglot-jl-julia-command
+        (concat "--project=" eglot-jl-base)
+        (expand-file-name "eglot-jl.jl" eglot-jl-base)
+        (eglot-jl--env (buffer-file-name))
+        eglot-jl-depot))
 
 ;;;###autoload
 (defun eglot-jl-init ()

--- a/eglot-jl.jl
+++ b/eglot-jl.jl
@@ -1,6 +1,7 @@
-import Pkg
-Pkg.activate(@__DIR__)
-
+# This script must be called with LOAD_PATH set to ["@"] so that the
+# wrong versions of packages aren't picked up. If called with the
+# normal LOAD_PATH, due to the stacked environments, this could pick
+# up a package from "@v#.#".
 try
     @eval using LanguageServer, SymbolServer
 catch
@@ -10,4 +11,7 @@ catch
 end#try
 
 server = LanguageServerInstance(stdin, stdout, false, ARGS[1], ARGS[2])
+# The run command starts additional julia processes which must have a
+# normal LOAD_PATH.
+delete!(ENV, "JULIA_LOAD_PATH")
 run(server)

--- a/eglot-jl.jl
+++ b/eglot-jl.jl
@@ -2,13 +2,12 @@
 # wrong versions of packages aren't picked up. If called with the
 # normal LOAD_PATH, due to the stacked environments, this could pick
 # up a package from "@v#.#".
-try
-    @eval using LanguageServer, SymbolServer
-catch
-    @warn "Unable to import LanguageServer. Instantiating project."
-    Pkg.instantiate()
-    @eval using LanguageServer, SymbolServer
-end#try
+import Pkg
+# In julia 1.4 this operation takes under a second. This can be
+# crushingly slow in older versions of julia though.
+Pkg.instantiate()
+
+using LanguageServer, SymbolServer
 
 server = LanguageServerInstance(stdin, stdout, false, ARGS[1], ARGS[2])
 # The run command starts additional julia processes which must have a


### PR DESCRIPTION
Older pinned versions of Julia packages were incompatible with julia
1.4. Version were bumped and a more robust way of making sure the
correct packages were found is added (by faffing about with
LOAD_PATH).

fixes #4 

@vvpisarev could you please confirm this works for you?