### PR TITLE
Add ability to pass custom flags to the Julia process

### DIFF
--- a/eglot-jl.el
+++ b/eglot-jl.el
@@ -42,6 +42,10 @@
   "Command to run the Julia executable."
   :type 'string)
 
+(defcustom eglot-jl-julia-flags nil
+  "Extra flags to pass to the Julia executable."
+  :type 'list)
+
 (defcustom eglot-jl-depot ""
   "Path or paths (space-separated) to Julia depots.
 An empty string uses the default depot for ‘eglot-jl-julia-command’
@@ -80,11 +84,12 @@ Otherwise returns nil"
   ;; The eglot-jl.jl script deletes this environment variable so that
   ;; subsequent julia processes will use the default LOAD_PATH.
   (setenv "JULIA_LOAD_PATH" "@")
-  (list eglot-jl-julia-command
-        (concat "--project=" eglot-jl-base)
-        (expand-file-name "eglot-jl.jl" eglot-jl-base)
-        (eglot-jl--env (buffer-file-name))
-        eglot-jl-depot))
+  (append (list eglot-jl-julia-command)
+          eglot-jl-julia-flags
+          (list (concat "--project=" eglot-jl-base)
+                (expand-file-name "eglot-jl.jl" eglot-jl-base)
+                (eglot-jl--env (buffer-file-name))
+                eglot-jl-depot)))
 
 ;;;###autoload
 (defun eglot-jl-init ()


### PR DESCRIPTION
Useful for specifying a sysimage file.

I'm setting it to:

``` emacs-lisp
(list "-J" (expand-file-name "~/.local/share/emacs/lsp-jl.so"))
```

After having created it with PackageCompiler.