### PR TITLE
Update to LanguageServer.jl v3

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "46ad13fcdde8dcb144f019b08bbd36be04cd429b"
+git-tree-sha1 = "a2f9009a81b92d078a682d4a8576adc1f8176e90"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "2.2.1"
+version = "2.3.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -19,15 +19,15 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocumentFormat]]
 deps = ["CSTParser", "FilePathsBase", "Tokenize"]
-git-tree-sha1 = "6ecbdc4d15126a89a689290a9e1aa0ce1d0a30e4"
+git-tree-sha1 = "eb34aa08aad1bc1ed5641b8c1f7fa4f478a4045f"
 uuid = "ffa9a821-9c82-50df-894e-fbcef3ed31cd"
-version = "2.1.1"
+version = "2.2.0"
 
 [[FilePathsBase]]
-deps = ["Dates", "LinearAlgebra", "Printf", "Test", "UUIDs"]
-git-tree-sha1 = "2cd6e2e7965934f72cb80251f760228e2264bab3"
+deps = ["Dates", "Printf", "Test", "UUIDs"]
+git-tree-sha1 = "7bb4a1867b009b15460ffc0bcce262d13d1e415e"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
-version = "0.7.0"
+version = "0.9.2"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -41,9 +41,9 @@ version = "0.21.0"
 
 [[LanguageServer]]
 deps = ["CSTParser", "DocumentFormat", "JSON", "REPL", "StaticLint", "SymbolServer", "Tokenize", "URIParser", "UUIDs"]
-git-tree-sha1 = "a526adeb56d15eafbeeedda48d6c8bb3ab24fd64"
+git-tree-sha1 = "7b427da55cec8c4690190e336139dee8a808016b"
 uuid = "2b0e0bc5-e4fd-59b4-8912-456d1b03d8d7"
-version = "2.0.1"
+version = "3.0.0"
 
 [[LibGit2]]
 deps = ["Printf"]
@@ -51,10 +51,6 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-
-[[LinearAlgebra]]
-deps = ["Libdl"]
-uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -68,9 +64,9 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "75d07cb840c300084634b4991761886d0d762724"
+git-tree-sha1 = "72c3451932513427caffbd8bab15643ad693804b"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.1"
+version = "1.0.3"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -99,15 +95,15 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[StaticLint]]
 deps = ["CSTParser", "Serialization", "SymbolServer"]
-git-tree-sha1 = "2c2d34f25c05e47462e562d0d9887de9cc652143"
+git-tree-sha1 = "91efea7df8e15c588d2557a151ac3c6e1560069d"
 uuid = "b3cc710f-9c33-5bdb-a03d-a94903873e97"
-version = "3.1.1"
+version = "4.3.0"
 
 [[SymbolServer]]
 deps = ["LibGit2", "Markdown", "Pkg", "REPL", "SHA", "Serialization", "Sockets", "UUIDs"]
-git-tree-sha1 = "a426ac836b7bc6cce4108ecfa1f299f4649dd80a"
+git-tree-sha1 = "43383798f7c4e78abc16eb741ee4656a4940bb38"
 uuid = "cf896787-08d5-524d-9de7-132aaa0cb996"
-version = "3.1.1"
+version = "4.4.0"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
@@ -119,10 +115,10 @@ uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 version = "0.5.8"
 
 [[URIParser]]
-deps = ["Test", "Unicode"]
-git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+deps = ["Unicode"]
+git-tree-sha1 = "53a9f49546b8d2dd2e688d216421d050c9a31d0d"
 uuid = "30578b45-9adc-5946-b283-645ec420af67"
-version = "0.4.0"
+version = "0.4.1"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,5 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SymbolServer = "cf896787-08d5-524d-9de7-132aaa0cb996"
 
 [compat]
-LanguageServer = "2.0.1"
-SymbolServer = "3.1.1"
+LanguageServer = "3"
 julia = "1"

--- a/eglot-jl.jl
+++ b/eglot-jl.jl
@@ -9,5 +9,5 @@ Pkg.instantiate()
 
 using LanguageServer, SymbolServer
 
-server = LanguageServerInstance(stdin, stdout, false, ARGS[1], ARGS[2])
+server = LanguageServerInstance(stdin, stdout, ARGS[1], ARGS[2])
 run(server)


### PR DESCRIPTION
This update should enable linting and document formatting by
default. See the eglot README for configuring options.