### PR TITLE
Let eglot-jl.jl determine the default project path

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,12 +30,12 @@ To work around this issue, you can:
 2. Run the following:
 
 #+begin_src sh
-  JULIA_LOAD_PATH="@" julia --project=path/to/eglot-jl/ path/to/eglot-jl/eglot-jl.jl path/to/project ""
+  julia --project path/to/eglot-jl/eglot-jl.jl
 #+end_src
 
 The SymbolServer is finished with caching dependencies when it
 displays:
 
 #+begin_quote
-[ Info: store set
+[ Info: Received new data from Julia Symbol Server.
 #+end_quote

--- a/README.org
+++ b/README.org
@@ -27,10 +27,10 @@ To work around this issue, you can:
 1. Set =eglot-connect-timeout= to a very high value.
    - Progress of the SymbolServer can be monitored in the =*EGLOT
      (ProjectName/julia-mode) stderr*= buffer.
-2. Run the following:
+2. Run the following, from your project directory:
 
 #+begin_src sh
-  julia --project path/to/eglot-jl/eglot-jl.jl
+  julia --project=path/to/eglot-jl/ path/to/eglot-jl/eglot-jl.jl
 #+end_src
 
 The SymbolServer is finished with caching dependencies when it

--- a/eglot-jl.el
+++ b/eglot-jl.el
@@ -51,22 +51,7 @@
 An empty string uses the default depot for ‘eglot-jl-julia-command’
 when the JULIA_DEPOT_PATH environment variable is not set."
   :type 'string)
-
-(defcustom eglot-jl-default-environment "~/.julia/environment/v1.2"
-  "Path to the Julia environment used if file not in a Julia Project."
-  :type 'string)
-
 (defconst eglot-jl-base (file-name-directory load-file-name))
-
-(defun eglot-jl--env (dir)
-  "Find the most relevant Julia Project for a given directory.
-If a parent directory to DIR contains a file JuliaProject.toml or
-Project.toml, that parent directory is used.  If not,
-`eglot-jl-default-environment' is used."
-  (expand-file-name (if dir (or (locate-dominating-file dir "JuliaProject.toml")
-                                (locate-dominating-file dir "Project.toml")
-                                eglot-jl-default-environment)
-                      eglot-jl-default-environment)))
 
 ;; Make project.el aware of Julia projects
 (defun eglot-jl--project-try (dir)
@@ -83,9 +68,8 @@ Otherwise returns nil"
   "Return list of strings to be called to start the Julia language server."
   `(,eglot-jl-julia-command
     ,@eglot-jl-julia-flags
-    ,(concat "--project=" eglot-jl-base)
+    "--project"
     ,(expand-file-name "eglot-jl.jl" eglot-jl-base)
-    ,(eglot-jl--env (buffer-file-name))
     ,eglot-jl-depot))
 
 ;;;###autoload

--- a/eglot-jl.el
+++ b/eglot-jl.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2019 Adam Beckmeyer
 
-;; Version: 1.2.0
+;; Version: 2.0.0
 ;; Author: Adam Beckmeyer <adam_git@thebeckmeyers.xyz>
 ;; Maintainer: Adam Beckmeyer <adam_git@thebeckmeyers.xyz>
 ;; URL: https://github.com/non-Jedi/eglot-jl
@@ -51,6 +51,7 @@
 An empty string uses the default depot for ‘eglot-jl-julia-command’
 when the JULIA_DEPOT_PATH environment variable is not set."
   :type 'string)
+
 (defconst eglot-jl-base (file-name-directory load-file-name))
 
 ;; Make project.el aware of Julia projects
@@ -68,8 +69,9 @@ Otherwise returns nil"
   "Return list of strings to be called to start the Julia language server."
   `(,eglot-jl-julia-command
     ,@eglot-jl-julia-flags
-    "--project"
+    ,(concat "--project=" eglot-jl-base)
     ,(expand-file-name "eglot-jl.jl" eglot-jl-base)
+    ,(file-name-directory (buffer-file-name))
     ,eglot-jl-depot))
 
 ;;;###autoload

--- a/eglot-jl.jl
+++ b/eglot-jl.jl
@@ -1,33 +1,34 @@
 # Usage:
-#   julia --project path/to/eglot-jl/eglot-jl.jl [DEPOT_PATH]
+#   julia --project=path/to/eglot-jl path/to/eglot-jl/eglot-jl.jl [SOURCE_PATH] [DEPOT_PATH]
 
-# Get the project environment.
-#
-# WARNING: this script must be called with the `--project` command-line switch
-# for this to work reliably.
-project_path = dirname(Base.load_path()[1])
+# Get the source path. In order of increasing priority:
+# - default value:  pwd()
+# - command-line:   ARGS[1]
+src_path = length(ARGS) >= 1 ? ARGS[1] : pwd()
 
-# Get the depot path. In order of increasing priority
-# - default value: ""
-# - environment:   ENV["JULIA_DEPOT_PATH"]
-# - command-line:  ARGS[1]
+# Get the depot path. In order of increasing priority:
+# - default value:  ""
+# - environment:    ENV["JULIA_DEPOT_PATH"]
+# - command-line:   ARGS[2]
 depot_path = get(ENV, "JULIA_DEPOT_PATH", "")
-if length(ARGS) >= 1
-    depot_path = ARGS[1]
+if length(ARGS) >= 2
+    depot_path = ARGS[2]
 end
 
-# Make sure that we only load packages from the eglot-jl environment specifically.
-import Pkg
-Pkg.activate(@__DIR__)
+# Get the project environment from the source path
+project_path = something(Base.current_project(src_path), Base.load_path_expand(LOAD_PATH[2])) |> dirname
+
+# Make sure that we only load packages from this environment specifically.
 empty!(LOAD_PATH)
 push!(LOAD_PATH, "@")
 
+import Pkg
 # In julia 1.4 this operation takes under a second. This can be
 # crushingly slow in older versions of julia though.
 Pkg.instantiate()
 
 using LanguageServer, SymbolServer
 
-@info "Running language server" env=Base.load_path()[1] src_path=pwd() project_path depot_path
+@info "Running language server" env=Base.load_path()[1] src_path project_path depot_path
 server = LanguageServerInstance(stdin, stdout, project_path, depot_path)
 run(server)

--- a/eglot-jl.jl
+++ b/eglot-jl.jl
@@ -1,13 +1,33 @@
-# Make sure that we only load packages from this environment specifically.
+# Usage:
+#   julia --project path/to/eglot-jl/eglot-jl.jl [DEPOT_PATH]
+
+# Get the project environment.
+#
+# WARNING: this script must be called with the `--project` command-line switch
+# for this to work reliably.
+project_path = dirname(Base.load_path()[1])
+
+# Get the depot path. In order of increasing priority
+# - default value: ""
+# - environment:   ENV["JULIA_DEPOT_PATH"]
+# - command-line:  ARGS[1]
+depot_path = get(ENV, "JULIA_DEPOT_PATH", "")
+if length(ARGS) >= 1
+    depot_path = ARGS[1]
+end
+
+# Make sure that we only load packages from the eglot-jl environment specifically.
+import Pkg
+Pkg.activate(@__DIR__)
 empty!(LOAD_PATH)
 push!(LOAD_PATH, "@")
 
-import Pkg
 # In julia 1.4 this operation takes under a second. This can be
 # crushingly slow in older versions of julia though.
 Pkg.instantiate()
 
 using LanguageServer, SymbolServer
 
-server = LanguageServerInstance(stdin, stdout, ARGS[1], ARGS[2])
+@info "Running language server" env=Base.load_path()[1] src_path=pwd() project_path depot_path
+server = LanguageServerInstance(stdin, stdout, project_path, depot_path)
 run(server)


### PR DESCRIPTION
Thanks for `eglot-jl`! I just switched from `lsp-mode`, and found the `eglot` experience much smoother thanks to your `eglot-jl` adapter.

This PR lets `eglot-jl.jl` determine the default project path. I see a few advantages to it:
- eglot-jl.el does not have to find the project itself (this could be extended to simplify `eglot-jl--project-try` as well)
- `eglot-jl-default-environment` becomes unnecessary
- the default environment is automatically adapted to the julia version in use

This also simplifies running the language server manually, since no argument is
mandatory anymore: when no arguments are provided, the default depot path is taken from the environment (or `""` if not found).