### PR TITLE
Default to --startup-file=no for language server process

### DIFF
--- a/eglot-jl.el
+++ b/eglot-jl.el
@@ -44,7 +44,7 @@
 
 (defcustom eglot-jl-julia-flags nil
   "Extra flags to pass to the Julia executable."
-  :type 'list)
+  :type '(repeat string))
 
 (defcustom eglot-jl-depot ""
   "Path or paths (space-separated) to Julia depots.
@@ -68,8 +68,9 @@ Otherwise returns nil"
 (defun eglot-jl--ls-invocation (_interactive)
   "Return list of strings to be called to start the Julia language server."
   `(,eglot-jl-julia-command
-    ,@eglot-jl-julia-flags
+    "--startup-file=no"
     ,(concat "--project=" eglot-jl-base)
+    ,@eglot-jl-julia-flags
     ,(expand-file-name "eglot-jl.jl" eglot-jl-base)
     ,(file-name-directory (buffer-file-name))
     ,eglot-jl-depot))


### PR DESCRIPTION
Fixes #10

Users can still override and use a startup-file since
eglot-jl-julia-flags is passed as a later flag to the julia
binary. This commit also moves eglot-jl-julia-flags to after the
--project flag so users can override if necessary.