### PR TITLE
Allow customizing environment language server run from

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 LanguageServer = "2b0e0bc5-e4fd-59b4-8912-456d1b03d8d7"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SymbolServer = "cf896787-08d5-524d-9de7-132aaa0cb996"
 
 [compat]

--- a/eglot-jl.el
+++ b/eglot-jl.el
@@ -33,6 +33,8 @@
 (require 'eglot)
 (require 'project)
 
+(defconst eglot-jl-base (file-name-directory load-file-name))
+
 (defgroup eglot-jl nil
   "Interaction with LanguageServer.jl LSP server via eglot"
   :prefix "eglot-jl-"
@@ -52,7 +54,11 @@ An empty string uses the default depot for ‘eglot-jl-julia-command’
 when the JULIA_DEPOT_PATH environment variable is not set."
   :type 'string)
 
-(defconst eglot-jl-base (file-name-directory load-file-name))
+(defcustom eglot-jl-language-server-project eglot-jl-base
+  "Julia project to run language server from.
+The project should have LanguageServer and SymbolServer packages
+available."
+  :type 'string)
 
 ;; Make project.el aware of Julia projects
 (defun eglot-jl--project-try (dir)
@@ -69,7 +75,7 @@ Otherwise returns nil"
   "Return list of strings to be called to start the Julia language server."
   `(,eglot-jl-julia-command
     "--startup-file=no"
-    ,(concat "--project=" eglot-jl-base)
+    ,(concat "--project=" eglot-jl-language-server-project)
     ,@eglot-jl-julia-flags
     ,(expand-file-name "eglot-jl.jl" eglot-jl-base)
     ,(file-name-directory (buffer-file-name))

--- a/eglot-jl.jl
+++ b/eglot-jl.jl
@@ -1,6 +1,14 @@
 # Usage:
 #   julia --project=path/to/eglot-jl path/to/eglot-jl/eglot-jl.jl [SOURCE_PATH] [DEPOT_PATH]
 
+# For convenience, Pkg isn't included in eglot-jl
+# Project.toml. Importing Pkg here relies on the standard library
+# being available on LOAD_PATH
+import Pkg
+# In julia 1.4 this operation takes under a second. This can be
+# crushingly slow in older versions of julia though.
+Pkg.instantiate()
+
 # Get the source path. In order of increasing priority:
 # - default value:  pwd()
 # - command-line:   ARGS[1]
@@ -21,11 +29,6 @@ project_path = something(Base.current_project(src_path), Base.load_path_expand(L
 # Make sure that we only load packages from this environment specifically.
 empty!(LOAD_PATH)
 push!(LOAD_PATH, "@")
-
-import Pkg
-# In julia 1.4 this operation takes under a second. This can be
-# crushingly slow in older versions of julia though.
-Pkg.instantiate()
 
 using LanguageServer, SymbolServer
 


### PR DESCRIPTION
Fixes #13.

This commit remove Pkg from the Project.toml since it can be loaded
with the standard library in LOAD_PATH. This is convenient when
developing LanguageServer.jl since it doesn't have Pkg in its
dependencies.

Thoughts on loading `Pkg` by assuming standard library is on LOAD_PATH
@ffevotte?