### PR TITLE
`preoject-roots` -> `project-root`

### DIFF
--- a/eglot-jl.el
+++ b/eglot-jl.el
@@ -68,8 +68,8 @@ Otherwise returns nil"
                   (locate-dominating-file dir "Project.toml"))))
     (and root (cons 'julia root))))
 
-(cl-defmethod project-roots ((project (head julia)))
-  (list (cdr project)))
+(cl-defmethod project-root ((project (head julia)))
+  (cdr project))
 
 (defun eglot-jl--ls-invocation (_interactive)
   "Return list of strings to be called to start the Julia language server."


### PR DESCRIPTION
I'm not sure this is correct and haven't tested it, but I was getting this warning on occasion
```
⛔ Warning (comp): eglot-jl.el:71:15: Warning: ‘project-roots’ is an obsolete function (as of 0.3.0); use ‘project-root’ instead.
```
`project-root` returns just a single value instead of a list, the assumption being that projects have only a single root.