### PR TITLE
Make eglot recognize ESS[julia] mode

### DIFF
--- a/eglot-jl.el
+++ b/eglot-jl.el
@@ -88,7 +88,7 @@ Otherwise returns nil"
   (add-hook 'project-find-functions #'eglot-jl--project-try)
   (add-to-list 'eglot-server-programs
                ;; function instead of strings to find project dir at runtime
-               '((julia-mode julia-ts-mode) . eglot-jl--ls-invocation)))
+               '((ess-julia-mode julia-mode julia-ts-mode) . eglot-jl--ls-invocation)))
 
 (provide 'eglot-jl)
 ;;; eglot-jl.el ends here


### PR DESCRIPTION
I have installed julia-mode following the steps of [ESS Wiki Julia](https://github.com/emacs-ess/ESS/wiki/Julia) which opens Julia files in ESS[julia] mode which eglot did not recognize.